### PR TITLE
Add support for pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/react-dom": "^17.0.9",
     "@types/webspeechapi": "^0.0.29",
     "@xstate/react": "^1.6.1",
+    "@xstate/inspect": "^0.5.2",
     "microsoft-cognitiveservices-speech-sdk": "^1.18.1",
     "node-sass": "^6.0.1",
     "react": "^17.0.2",
@@ -52,7 +53,6 @@
     ]
   },
   "devDependencies": {
-      "gh-pages": "^3.2.3",
-      "@xstate/inspect": "^0.5.0"
+      "gh-pages": "^3.2.3"
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -24,11 +24,41 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Tala Speech</title>
   </head>
   <body>
+    <div class="chapterbuttons" id="cbs"></div>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script>
+      console.log(window.availableDDDs);
+      
+      const listener = (event) => {
+          window.availableDDDs = event.detail
+	  for (let [i, pg] of window.availableDDDs.entries()) {
+	      console.log(pg);
+	      btn = document.createElement("button");
+	      btn.id = `cb${i}`;
+              btn.onclick =  function() { turnPage({"pageNumber": i, "dddName": pg});}
+	      btn.textContent = pg;
+	      document.getElementById("cbs").appendChild(btn)
+          }
+      };
+      window.addEventListener('setAvailableDDDs', listener);
+
+      
+      let page = 0;
+      const turnPage = (segment) => {
+	  console.log(segment)
+	  if (document.getElementById(`cb${page}`) !== null) {
+	      document.getElementById(`cb${page}`).style.fontWeight = 'normal'
+              }
+	  page = segment.pageNumber;
+	  document.getElementById(`cb${page}`).style.fontWeight = 'bold'
+	  event = new CustomEvent('turnpage', { detail: segment });
+	  window.dispatchEvent(event);
+      }
+    </script>
     <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,6 +4,7 @@ import * as ReactDOM from "react-dom";
 import { Machine, assign, actions, State } from "xstate";
 import { useMachine, asEffect } from "@xstate/react";
 import { tdmDmMachine } from "./tdmClient";
+import { inspect } from "@xstate/inspect";
 
 import createSpeechRecognitionPonyfill from 'web-speech-cognitive-services/lib/SpeechServices/SpeechToText'
 import createSpeechSynthesisPonyfill from 'web-speech-cognitive-services/lib/SpeechServices/TextToSpeech';
@@ -19,14 +20,25 @@ const REGION = 'northeurope';
 
 const defaultPassivity = 5
 
+
+if (process.env.NODE_ENV === 'development') {
+    inspect({
+        url: "https://statecharts.io/inspect",
+        iframe: false
+    });
+}
+
+
 const machine = Machine<SDSContext, any, SDSEvent>({
     id: 'root',
     type: 'parallel',
+    invoke: {
+        src: 'checkForPage',
+    },
     states: {
         dm: {
             ...dm
         },
-
         gui: {
             initial: 'micOnly',
             states: {
@@ -35,162 +47,158 @@ const machine = Machine<SDSContext, any, SDSEvent>({
                 },
                 showAlternatives: {
                     on: { SELECT: 'micOnly' },
-                }
-            }
+                },
+            },
         },
-
         asrtts: {
-            initial: 'init',
+            initial: 'initialize',
             states: {
-                init: {
+                initialize: {
+                    initial: 'await',
                     on: {
-                        CLICK: {
-                            target: 'getToken',
-                            actions: [
-                                assign({
-                                    audioCtx: (_ctx) =>
-                                        new ((window as any).AudioContext || (window as any).webkitAudioContext)()
-                                }),
-                                (context) =>
-                                    navigator.mediaDevices.getUserMedia({ audio: true })
-                                        .then(function(stream) { context.audioCtx.createMediaStreamSource(stream) })
-                            ]
-                        }
-                    }
-                },
-                getToken: {
-                    invoke: {
-                        id: "getAuthorizationToken",
-                        src: (_ctx, _evt) => getAuthorizationToken(),
-                        onDone: {
-                            actions: [
-                                assign((_context, event) => { return { azureAuthorizationToken: event.data } }),
-                                'ponyfillASR'],
-                            target: 'ponyfillTTS'
-                        },
-                        onError: {
-                            target: 'fail'
-                        }
-                    }
-                },
-                ponyfillTTS: {
-                    invoke: {
-                        id: 'ponyTTS',
-                        src: (context, _event) => (callback, _onReceive) => {
-                            const ponyfill = createSpeechSynthesisPonyfill({
-                                audioContext: context.audioCtx,
-                                credentials: {
-                                    region: REGION,
-                                    authorizationToken: context.azureAuthorizationToken,
-                                }
-                            });
-                            const { speechSynthesis, SpeechSynthesisUtterance } = ponyfill;
-                            context.tts = speechSynthesis
-                            context.ttsUtterance = SpeechSynthesisUtterance
-                            context.tts.addEventListener('voiceschanged', () => {
-                                context.tts.cancel()
-                                const voices = context.tts.getVoices();
-                                let voiceRe = RegExp("en-US", 'u')
-                                if (Config.TTS_VOICE) {
-                                    voiceRe = RegExp(Config.TTS_VOICE, 'u')
-                                }
-                                const voice = voices.find((v: any) => voiceRe.test(v.name))!
-                                if (voice) {
-                                    context.voice = voice
-                                    callback('TTS_READY')
-                                } else {
-                                    console.error(`TTS_ERROR: Could not get voice for regexp ${voiceRe}`)
-                                    callback('TTS_ERROR')
-                                }
-                            })
-                        }
-                    },
-                    on: {
-                        TTS_READY: 'idle',
-                        TTS_ERROR: 'fail'
-                    }
-                },
-                idle: {
-                    on: {
-                        LISTEN: 'recognising',
-                        SPEAK: {
-                            target: 'speaking',
-                            actions: assign((_context, event) => { return { ttsAgenda: event.value } })
-                        }
-                    },
-                },
-                recognising: {
-                    initial: 'noinput',
-                    exit: 'recStop',
-                    on: {
-                        ASRRESULT: {
-                            actions: ['recLogResult',
-                                assign((_context, event) => {
-                                    return {
-                                        recResult: event.value
-                                    }
-                                })],
-                            target: '.match'
-                        },
-                        RECOGNISED: 'idle',
-                        SELECT: 'idle',
-                        CLICK: '.pause',
-                        TIMEOUT: '#root.asrtts.idle'
+                        TTS_READY: 'ready',
+                        TTS_ERROR: '.fail'
                     },
                     states: {
-                        noinput: {
-                            entry: [
-                                'recStart',
-                                send(
-                                    { type: 'TIMEOUT' },
-                                    {
-                                        delay: (context) => (1000 * (context.tdmPassivity ?? defaultPassivity)),
-                                        id: 'timeout'
-                                    }
-                                )],
+                        fail: {},
+                        await: {
                             on: {
-                                STARTSPEECH: 'inprogress'
+                                CLICK: {
+                                    target: 'getToken',
+                                    actions: [
+                                        assign({
+                                            audioCtx: (_ctx) =>
+                                                new ((window as any).AudioContext || (window as any).webkitAudioContext)()
+                                        }),
+                                        (context) =>
+                                            navigator.mediaDevices.getUserMedia({ audio: true })
+                                                .then(function(stream) { context.audioCtx.createMediaStreamSource(stream) })
+                                    ]
+                                }
+                            }
+                        },
+                        getToken: {
+                            invoke: {
+                                id: "getAuthorizationToken",
+                                src: (_ctx, _evt) => getAuthorizationToken(),
+                                onDone: {
+                                    actions: [
+                                        assign((_context, event) => { return { azureAuthorizationToken: event.data } }),
+                                        'ponyfillASR'],
+                                    target: 'ponyfillTTS'
+                                },
+                                onError: {
+                                    target: 'fail'
+                                }
+                            }
+                        },
+                        ponyfillTTS: {
+                            invoke: {
+                                id: 'ponyTTS',
+                                src: (context, _event) => (callback, _onReceive) => {
+                                    const ponyfill = createSpeechSynthesisPonyfill({
+                                        audioContext: context.audioCtx,
+                                        credentials: {
+                                            region: REGION,
+                                            authorizationToken: context.azureAuthorizationToken,
+                                        }
+                                    });
+                                    const { speechSynthesis, SpeechSynthesisUtterance } = ponyfill;
+                                    context.tts = speechSynthesis
+                                    context.ttsUtterance = SpeechSynthesisUtterance
+                                    context.tts.addEventListener('voiceschanged', () => {
+                                        context.tts.cancel()
+                                        const voices = context.tts.getVoices();
+                                        let voiceRe = RegExp("en-US", 'u')
+                                        if (Config.TTS_VOICE) {
+                                            voiceRe = RegExp(Config.TTS_VOICE, 'u')
+                                        }
+                                        const voice = voices.find((v: any) => voiceRe.test(v.name))!
+                                        if (voice) {
+                                            context.voice = voice
+                                            callback('TTS_READY')
+                                        } else {
+                                            console.error(`TTS_ERROR: Could not get voice for regexp ${voiceRe}`)
+                                            callback('TTS_ERROR')
+                                        }
+                                    })
+                                }
                             },
-                            exit: cancel('timeout')
-                        },
-                        inprogress: {
-                        },
-                        match: {
-                            entry: send('RECOGNISED'),
-                        },
-                        pause: {
-                            entry: 'recStop',
-                            on: { CLICK: 'noinput' }
                         }
-                    }
-                },
-                speaking: {
-                    entry: ['recStop', 'ttsStart'],
-                    on: {
-                        ENDSPEECH: 'idle',
-                        SELECT: 'idle',
-                        CLICK: { target: 'idle', actions: send('ENDSPEECH') }
                     },
-                    exit: 'ttsStop',
                 },
-                fail: {}
-            }
-        }
-    },
-},
-    {
-        actions: {
-            recLogResult: (context: SDSContext) => {
-                /* context.recResult = event.recResult; */
-                console.log('U>', context.recResult[0]["utterance"],
-                    { "confidence": context.recResult[0]["confidence"] });
+                ready: {
+                    initial: 'idle',
+                    states: {
+                        idle: {
+                            on: {
+                                LISTEN: 'recognising',
+                                SPEAK: {
+                                    target: 'speaking',
+                                    actions: assign((_context, event) => { return { ttsAgenda: event.value } })
+                                }
+                            },
+                        },
+                        recognising: {
+                            initial: 'noinput',
+                            exit: 'recStop',
+                            on: {
+                                ASRRESULT: {
+                                    actions: ['recLogResult',
+                                        assign((_context, event) => {
+                                            return {
+                                                recResult: event.value
+                                            }
+                                        })],
+                                    target: '.match'
+                                },
+                                RECOGNISED: 'idle',
+                                SELECT: 'idle',
+                                CLICK: '.pause',
+                                TIMEOUT: '#root.asrtts.ready.idle'
+                            },
+                            states: {
+                                noinput: {
+                                    entry: [
+                                        'recStart',
+                                        send(
+                                            { type: 'TIMEOUT' },
+                                            {
+                                                delay: (context) => (1000 * (context.tdmPassivity ?? defaultPassivity)),
+                                                id: 'timeout'
+                                            }
+                                        )],
+                                    on: {
+                                        STARTSPEECH: 'inprogress'
+                                    },
+                                    exit: cancel('timeout')
+                                },
+                                inprogress: {
+                                },
+                                match: {
+                                    entry: send('RECOGNISED'),
+                                },
+                                pause: {
+                                    entry: 'recStop',
+                                    on: { CLICK: 'noinput' }
+                                }
+                            }
+                        },
+                        speaking: {
+                            entry: ['recStop', 'ttsStart'],
+                            on: {
+                                ENDSPEECH: 'idle',
+                                SELECT: 'idle',
+                                CLICK: { target: 'idle', actions: send('ENDSPEECH') }
+                            },
+                            exit: 'ttsStop',
+                        },
+                    },
+                },
             },
-            logIntent: (context: SDSContext) => {
-                /* context.nluData = event.data */
-                console.log('<< NLU intent: ' + context.nluData.intent.name)
-            }
         },
-    });
+    },
+});
 
 
 
@@ -207,14 +215,14 @@ const ReactiveButton = (props: Props): JSX.Element => {
     switch (true) {
         case props.state.matches({ asrtts: 'fail' }) || props.state.matches({ dm: 'fail' }):
             break;
-        case props.state.matches({ asrtts: { recognising: 'pause' } }):
+        case props.state.matches({ asrtts: { ready: { recognising: 'pause' } } }):
             promptText = "Click to continue"
             break;
-        case props.state.matches({ asrtts: 'recognising' }):
+        case props.state.matches({ asrtts: { ready: 'recognising' } }):
             circleClass = "circle-recognising"
             promptText = promptText || 'Listening...'
             break;
-        case props.state.matches({ asrtts: 'speaking' }):
+        case props.state.matches({ asrtts: { ready: 'speaking' } }):
             circleClass = "circle-speaking"
             promptText = promptText || 'Speaking...'
             break;
@@ -260,9 +268,32 @@ const FigureButton = (props: Props): JSX.Element => {
     )
 }
 
+const tdmContext = { segment: { pageNumber: 0, dddName: "cover" } }
 function App() {
-    const [current, send] = useMachine(machine, {
+    const [current, send] = useMachine(machine.withContext({ ...machine.context, ...tdmContext }), {
+        devTools: process.env.NODE_ENV === 'development' ? true : false,
+        services: {
+            checkForPage: () => (send) => {
+                const listener = (e: any) => {
+                    send({ type: 'TURNPAGE', value: e.detail });
+                };
+
+                window.addEventListener('turnpage', listener);
+
+                return () => {
+                    window.removeEventListener('turnpage', listener);
+                };
+            },
+        },
         actions: {
+            setAvailableDDDs: asEffect((context) => {
+                const event = new CustomEvent<any>('setAvailableDDDs', { detail: context.tdmAvailableDDDs });
+                window.dispatchEvent(event);
+            }),
+            recLogResult: (context: SDSContext) => {
+                console.log('U>', context.recResult[0]["utterance"],
+                    { "confidence": context.recResult[0]["confidence"] });
+            },
             recStart: asEffect((context) => {
                 context.asr.start()
                 /* console.log('Ready to receive a voice input.'); */

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -9,6 +9,11 @@ interface Hypothesis {
     "confidence": number
 }
 
+interface Segment {
+    "pageNumber": number;
+    "dddName": string
+}
+
 interface MySpeechSynthesisUtterance extends SpeechSynthesisUtterance {
     new(s: string);
 }
@@ -31,15 +36,20 @@ interface SDSContext {
     sessionObject: any;
     tdmAll: any;
     tdmUtterance: string;
+    segment: Segment;
     tdmPassivity: number;
     tdmActions: any;
     tdmVisualOutputInfo: any;
     tdmExpectedAlternatives: any;
+    tdmOutput: any;
+    tdmActiveDDD: string;
+    tdmAvailableDDDs: string[];
     azureAuthorizationToken: string;
     audioCtx: any;
 }
 
 type SDSEvent =
+    | { type: 'TURNPAGE', value: Segment }
     | { type: 'TTS_READY' }
     | { type: 'TTS_ERROR' }
     | { type: 'CLICK' }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -25,6 +25,19 @@ html, body {
     height: 100vh;
 }
 
+.chapterbuttons {
+    display: flex;
+    flex-flow: row wrap;
+    margin: 10px;
+    button[id^="cb"] {
+	font-family: IBM Plex Mono, monospace;
+	padding: 10px;
+    }
+    button[class^="active-cb"] {
+	font-family: IBM Plex Mono, monospace;
+	padding: 10px;
+    }
+}
 .control {
     top: 70vh;
     margin-bottom: auto;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2292,10 +2292,10 @@
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
 
-"@xstate/inspect@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@xstate/inspect/-/inspect-0.5.0.tgz#212a874bdb2f72dc846bb1341502ca85d05cb531"
-  integrity sha512-AOCK513vmueAAM6bQCPrvlPdHaMH3X7AgvVr0pAYzFHvV2SBhPZCX9TQXRrOmIplqByRjb34puPUbYRjkmLHww==
+"@xstate/inspect@^0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@xstate/inspect/-/inspect-0.5.2.tgz#83d58c96f704ceaab6f7849e578d8e6ce212038c"
+  integrity sha512-DdqUPiKaHW6VpnVZcm8YMD8LBeS3B9bB3+VT/6VEyilgvf2MgYzho2dKOOkeZM0iDEadSmzGdDpz0jh7DSpMXQ==
   dependencies:
     fast-safe-stringify "^2.0.7"
 


### PR DESCRIPTION
This change allows the frontend to read available book segments (DDDs)
and updates static html page with the buttons for to the available
DDDs. Clicking a button sets a haptic input which is sent immediately
after start_session request to TDM.