### PR TITLE
Allow using Azure authorization tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tala-speech",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "GPL-3.0",
   "homepage": "http://example.com",
   "private": true,

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -19,7 +19,7 @@ interface Settings {
     ttsVoice: string;
     ttsLexicon: string;
     asrLanguage: string;
-    azureKey: string;
+    azureKey?: string;
     completeTimeout: number;
     i18nClickToStart: string;
     i18nListening: string;

--- a/static/test.html
+++ b/static/test.html
@@ -25,8 +25,8 @@
     </style>
 </head>
 <body>
-    <div id="root"
-         data-azure-key="2e15e033f605414bbbfe26cb631ab755"
+    <div id="tala-speech"
+	 data-azure-authorization-token="<generate token>"
          data-tdm-endpoint="https://sfi-mataffaren-orchestration-test-pipeline.eu2.ddd.tala.cloud/interact"
          data-tts-voice="sv-SE, SofieNeural"
          data-asr-language="sv-SE"


### PR DESCRIPTION
If Azure key is not specified, tala-speech doesn't request a
token. It presupposes that token is provided via the argument
"data-azure-authorization-token" and uses it instead.

Additionally, now the root element is named "tala-speech".