### PR TITLE
Add external event for closing the widget

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,6 +38,7 @@ const machine = Machine<SDSContext, any, SDSEvent>({
     },
     gui: {
       initial: "micOnly",
+      on: { STOP: ".micOnly" },
       states: {
         micOnly: {
           on: { SHOW_ALTERNATIVES: "showAlternatives" },
@@ -49,7 +50,9 @@ const machine = Machine<SDSContext, any, SDSEvent>({
     },
     asrtts: {
       initial: "initialize",
+      on: { STOP: ".stopped" },
       states: {
+        stopped: { on: { CLICK: "initialize" } },
         initialize: {
           initial: "await",
           on: {
@@ -375,15 +378,18 @@ function App({ domElement }: any) {
         getListeners: () => (send) => {
           const clickListener = () => send("CLICK");
           const pauseListener = () => send("PAUSE");
+          const stopListener = () => send("STOP");
           const turnPageListener = (e: any) => {
             send({ type: "TURNPAGE", value: e.detail });
           };
           window.addEventListener("talaClick", clickListener);
           window.addEventListener("talaPause", pauseListener);
+          window.addEventListener("talaStop", stopListener);
           window.addEventListener("turnpage", turnPageListener);
           return () => {
             window.removeEventListener("talaClick", clickListener);
             window.removeEventListener("talaPause", pauseListener);
+            window.removeEventListener("talaStop", stopListener);
             window.removeEventListener("turnpage", turnPageListener);
           };
         },

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -69,6 +69,7 @@ type SDSEvent =
   | { type: "TTS_ERROR" }
   | { type: "CLICK" }
   | { type: "PAUSE" }
+  | { type: "STOP" }
   | { type: "SELECT"; value: any }
   | { type: "SHOW_ALTERNATIVES" }
   | { type: "ASR_START" }

--- a/src/tdmClient.ts
+++ b/src/tdmClient.ts
@@ -2,288 +2,329 @@ import { MachineConfig, actions, AssignAction } from "xstate";
 
 const { send, assign, choose } = actions;
 
-
 const startSession = {
-    "version": "3.3",
-    "session": { "device_id": "tala-speech" },
-    "request": {
-        "start_session": {},
-    }
-}
+  version: "3.3",
+  session: { device_id: "tala-speech" },
+  request: {
+    start_session: {},
+  },
+};
 
 const passivity = (sessionObject: any) => ({
-    "version": "3.3",
-    "session": sessionObject,
-    "request": {
-        "passivity": {}
-    }
-})
+  version: "3.3",
+  session: sessionObject,
+  request: {
+    passivity: {},
+  },
+});
 
-const nlInput = (sessionObject: any, ddd: string, moves: any, hypotheses: Hypothesis[]) => ({
-    "version": "3.3",
-    "session": {
-        ...sessionObject,
-        "ddd": ddd,
-        "moves": moves
+const nlInput = (
+  sessionObject: any,
+  ddd: string,
+  moves: any,
+  hypotheses: Hypothesis[]
+) => ({
+  version: "3.3",
+  session: {
+    ...sessionObject,
+    ddd: ddd,
+    moves: moves,
+  },
+  request: {
+    natural_language_input: {
+      modality: "speech",
+      hypotheses: hypotheses,
     },
-    "request": {
-        "natural_language_input": {
-            "modality": "speech",
-            "hypotheses": hypotheses
-        }
-    }
-})
+  },
+});
 
 const segmentInput = (sessionObject: any, ddd: string) => ({
-    "version": "3.3",
-    "session": sessionObject,
-    "request": {
-        "semantic_input": {
-            "interpretations": [{
-                "modality": "other",
-                "moves": [{
-                    "ddd": ddd,
-                    "perception_confidence": 1,
-                    "understanding_confidence": 1,
-                    "semantic_expression": "request(top)"
-                }]
-            }]
-        }
-    }
-})
+  version: "3.3",
+  session: sessionObject,
+  request: {
+    semantic_input: {
+      interpretations: [
+        {
+          modality: "other",
+          moves: [
+            {
+              ddd: ddd,
+              perception_confidence: 1,
+              understanding_confidence: 1,
+              semantic_expression: "request(top)",
+            },
+          ],
+        },
+      ],
+    },
+  },
+});
 
 const hapticInput = (sessionObject: any, alternative: any) => ({
-    "version": "3.3",
-    "session": sessionObject,
-    "request": {
-        "semantic_input": {
-            "interpretations": [{
-                "modality": "haptic",
-                "moves": [{
-                    "perception_confidence": 1,
-                    "understanding_confidence": 1,
-                    "semantic_expression": alternative.semantic_expression
-                }]
-            }]
-        }
-    }
-})
-
-
-const tdmRequest = (endpoint: string, requestBody: any) => (fetch(new Request(endpoint, {
-    method: 'POST',
-    headers: {
-        'Content-type': 'application/json'
+  version: "3.3",
+  session: sessionObject,
+  request: {
+    semantic_input: {
+      interpretations: [
+        {
+          modality: "haptic",
+          moves: [
+            {
+              perception_confidence: 1,
+              understanding_confidence: 1,
+              semantic_expression: alternative.semantic_expression,
+            },
+          ],
+        },
+      ],
     },
-    body: JSON.stringify(requestBody)
-})).then(data => data.json()))
+  },
+});
+
+const tdmRequest = (endpoint: string, requestBody: any) =>
+  fetch(
+    new Request(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-type": "application/json",
+      },
+      body: JSON.stringify(requestBody),
+    })
+  ).then((data) => data.json());
 
 const tdmAssign: AssignAction<SDSContext, any> = assign({
-    sessionObject: (_ctx, event) => event.data.session,
-    tdmAll: (_ctx, event) => event.data,
-    tdmOutput: (_ctx, event) => event.data.output,
-    tdmActiveDDD: (_ctx, event) => event.data.context.active_ddd,
-    tdmAvailableDDDs: (_ctx, event) => event.data.context.available_ddds,
-    tdmUtterance: (_ctx, event) => event.data.output.utterance,
-    tdmVisualOutputInfo: (_ctx, event) => (event.data.output.visual_output || [{}])[0].visual_information,
-    tdmExpectedAlternatives: (_ctx, event) => (event.data.context.expected_input || {}).alternatives,
-    tdmPassivity: (_ctx, event) => event.data.output.expected_passivity,
-    tdmActions: (_ctx, event) => event.data.output.actions,
-    tdmAsrHints: (_ctx, event) => event.data.context.asr_hints
-})
-
+  sessionObject: (_ctx, event) => event.data.session,
+  tdmAll: (_ctx, event) => event.data,
+  tdmOutput: (_ctx, event) => event.data.output,
+  tdmActiveDDD: (_ctx, event) => event.data.context.active_ddd,
+  tdmAvailableDDDs: (_ctx, event) => event.data.context.available_ddds,
+  tdmUtterance: (_ctx, event) => event.data.output.utterance,
+  tdmVisualOutputInfo: (_ctx, event) =>
+    (event.data.output.visual_output || [{}])[0].visual_information,
+  tdmExpectedAlternatives: (_ctx, event) =>
+    (event.data.context.expected_input || {}).alternatives,
+  tdmPassivity: (_ctx, event) => event.data.output.expected_passivity,
+  tdmActions: (_ctx, event) => event.data.output.actions,
+  tdmAsrHints: (_ctx, event) => event.data.context.asr_hints,
+});
 
 const maybeAlternatives = choose<SDSContext, SDSEvent>([
-    {
-        cond: (context) => { return (context.tdmExpectedAlternatives || [{}])[0].visual_information },
-        actions: [send({ type: "SHOW_ALTERNATIVES" })]
+  {
+    cond: (context) => {
+      return (context.tdmExpectedAlternatives || [{}])[0].visual_information;
     },
-])
+    actions: [send({ type: "SHOW_ALTERNATIVES" })],
+  },
+]);
 
-export const tdmDmMachine: MachineConfig<SDSContext, any, SDSEvent> = ({
-    initial: 'getPages',
-    on: {
-        'TURNPAGE': {
-            actions: [assign({ segment: (_ctx, event) => event.value })]
-        }
+export const tdmDmMachine: MachineConfig<SDSContext, any, SDSEvent> = {
+  initial: "getPages",
+  on: {
+    TURNPAGE: {
+      actions: [assign({ segment: (_ctx, event) => event.value })],
     },
-    states: {
-        fail: {},
-        getPages: {
-            invoke: {
-                id: "startSession",
-                src: (context, _evt) => tdmRequest(context.parameters.endpoint, startSession),
-                onDone: [
-                    {
-                        target: 'idle',
-                        actions: [tdmAssign, 'setAvailableDDDs'],
-                        cond: (_ctx, event) => event.data.output
-                    },
-                    {
-                        target: 'fail'
-                    }
+    STOP: ".stopped",
+  },
+  states: {
+    fail: {},
+    stopped: { on: { CLICK: "getPages" } },
+    getPages: {
+      invoke: {
+        id: "startSession",
+        src: (context, _evt) =>
+          tdmRequest(context.parameters.endpoint, startSession),
+        onDone: [
+          {
+            target: "idle",
+            actions: [tdmAssign, "setAvailableDDDs"],
+            cond: (_ctx, event) => event.data.output,
+          },
+          {
+            target: "fail",
+          },
+        ],
+        onError: { target: "fail" },
+      },
+    },
+    idle: {
+      on: {
+        CLICK: "init",
+        SELECT: {
+          actions: [
+            send("CLICK"),
+            assign({
+              segment: (_ctx, event) => ({
+                dddName: event.value.ddd,
+                pageNumber: 0,
+              }),
+            }),
+          ],
+        },
+      },
+    },
+    init: {
+      on: {
+        TTS_READY: "tdm",
+        CLICK: "tdm",
+      },
+    },
+    tdm: {
+      initial: "start",
+      states: {
+        start: {
+          invoke: {
+            id: "startSession",
+            src: (context, _evt) =>
+              tdmRequest(context.parameters.endpoint, startSession),
+            onDone: [
+              {
+                target: "selectSegment",
+                actions: tdmAssign,
+                cond: (_ctx, event) => event.data.output,
+              },
+              {
+                target: "fail",
+              },
+            ],
+            onError: { target: "fail" },
+          },
+        },
+        selectSegment: {
+          invoke: {
+            id: "segmentInput",
+            src: (context, _evt) =>
+              tdmRequest(
+                context.parameters.endpoint,
+                segmentInput(context.sessionObject, context.segment.dddName)
+              ),
+            onDone: [
+              {
+                target: "utter",
+                actions: tdmAssign,
+                cond: (_ctx, event) => event.data.output,
+              },
+              {
+                target: "fail",
+              },
+            ],
+            onError: { target: "fail" },
+          },
+        },
+        utter: {
+          initial: "prompt",
+          on: {
+            RECOGNISED: "next",
+            SELECT: {
+              target: "nextHaptic",
+              actions: assign({ hapticInput: (_ctx, event) => event.value }),
+            },
+            TIMEOUT: "passivity",
+          },
+          states: {
+            prompt: {
+              entry: [
+                maybeAlternatives,
+                send((context: SDSContext) => ({
+                  type: "SPEAK",
+                  value: context.tdmUtterance,
+                })),
+              ],
+              on: {
+                ENDSPEECH: [
+                  {
+                    target: "#root.dm.init",
+                    cond: (context) =>
+                      context.tdmActions.some((item: any) =>
+                        [
+                          "EndOfSection",
+                          "EndSession",
+                          "EndConversation",
+                        ].includes(item.name)
+                      ),
+                  },
+                  {
+                    target: "#root.dm.tdm.passivity",
+                    cond: (context) => context.tdmPassivity === 0,
+                  },
+                  { target: "ask" },
                 ],
-                onError: { target: 'fail' }
-            }
-        },
-        idle: {
-            on: {
-                CLICK: 'init',
-                SELECT: {
-                    actions: [send('CLICK'), assign({
-                        segment: (_ctx, event) => ({
-                            dddName: event.value.ddd,
-                            pageNumber: 0
-                        })
-                    })]
-                }
+              },
             },
-        },
-        init: {
-            on: {
-                TTS_READY: 'tdm',
-                CLICK: 'tdm',
-            }
-        },
-        tdm: {
-            initial: 'start',
-            states: {
-                start: {
-                    invoke: {
-                        id: "startSession",
-                        src: (context, _evt) => tdmRequest(context.parameters.endpoint, startSession),
-                        onDone: [
-                            {
-                                target: 'selectSegment',
-                                actions: tdmAssign,
-                                cond: (_ctx, event) => event.data.output
-                            },
-                            {
-                                target: 'fail'
-                            }
-                        ],
-                        onError: { target: 'fail' }
-                    }
-                },
-                selectSegment: {
-                    invoke: {
-                        id: "segmentInput",
-                        src: (context, _evt) => tdmRequest(context.parameters.endpoint,
-                            segmentInput(context.sessionObject, context.segment.dddName)),
-                        onDone: [
-                            {
-                                target: 'utter',
-                                actions: tdmAssign,
-                                cond: (_ctx, event) => event.data.output
-                            },
-                            {
-                                target: 'fail'
-                            }
-                        ],
-                        onError: { target: 'fail' }
-                    }
-                },
-                utter: {
-                    initial: 'prompt',
-                    on: {
-                        RECOGNISED: 'next',
-                        SELECT: {
-                            target: 'nextHaptic',
-                            actions: assign({ hapticInput: (_ctx, event) => event.value })
-                        },
-                        TIMEOUT: 'passivity'
-                    },
-                    states: {
-                        prompt: {
-                            entry: [
-                                maybeAlternatives,
-                                send((context: SDSContext) => ({
-                                    type: "SPEAK", value: context.tdmUtterance
-                                }))],
-                            on: {
-                                ENDSPEECH:
-                                    [
-                                        {
-                                            target: '#root.dm.init',
-                                            cond: (context) =>
-                                                context.tdmActions.some(
-                                                    (item: any) =>
-                                                        ['EndOfSection', 'EndSession', 'EndConversation'].includes(item.name))
-                                        },
-                                        {
-                                            target: '#root.dm.tdm.passivity',
-                                            cond: (context) => context.tdmPassivity === 0
-                                        },
-                                        { target: 'ask' }
-                                    ]
-
-                            }
-                        },
-                        ask: {
-                            entry: send('LISTEN')
-                        },
-                    }
-                },
-                next: {
-                    invoke: {
-                        id: "nlInput",
-                        src: (context, _evt) => tdmRequest(context.parameters.endpoint,
-                            nlInput(context.sessionObject,
-                                context.tdmActiveDDD,
-                                context.tdmOutput.moves,
-                                context.recResult)),
-                        onDone: [
-                            {
-                                target: 'utter',
-                                actions: tdmAssign,
-                                cond: (_ctx, event) => event.data.output
-                            },
-                            {
-                                target: 'fail'
-                            }
-                        ],
-                        onError: { target: 'fail' }
-                    }
-                },
-                nextHaptic: {
-                    invoke: {
-                        id: "hapticInput",
-                        src: (context, _evt) => tdmRequest(context.parameters.endpoint,
-                            hapticInput(context.sessionObject, context.hapticInput)),
-                        onDone: [
-                            {
-                                target: 'utter',
-                                actions: tdmAssign,
-                                cond: (_ctx, event) => event.data.output
-                            },
-                            {
-                                target: 'fail'
-                            }
-                        ],
-                        onError: { target: 'fail' }
-                    }
-                },
-                passivity: {
-                    invoke: {
-                        id: "passivity",
-                        src: (context, _evt) => tdmRequest(context.parameters.endpoint,
-                            passivity(context.sessionObject)),
-                        onDone: [
-                            {
-                                target: 'utter',
-                                actions: tdmAssign,
-                                cond: (_ctx, event) => event.data.output
-                            },
-                            {
-                                target: 'fail'
-                            }
-                        ],
-                        onError: { target: 'fail' }
-                    }
-
-                },
-                fail: {}
+            ask: {
+              entry: send("LISTEN"),
             },
+          },
         },
+        next: {
+          invoke: {
+            id: "nlInput",
+            src: (context, _evt) =>
+              tdmRequest(
+                context.parameters.endpoint,
+                nlInput(
+                  context.sessionObject,
+                  context.tdmActiveDDD,
+                  context.tdmOutput.moves,
+                  context.recResult
+                )
+              ),
+            onDone: [
+              {
+                target: "utter",
+                actions: tdmAssign,
+                cond: (_ctx, event) => event.data.output,
+              },
+              {
+                target: "fail",
+              },
+            ],
+            onError: { target: "fail" },
+          },
+        },
+        nextHaptic: {
+          invoke: {
+            id: "hapticInput",
+            src: (context, _evt) =>
+              tdmRequest(
+                context.parameters.endpoint,
+                hapticInput(context.sessionObject, context.hapticInput)
+              ),
+            onDone: [
+              {
+                target: "utter",
+                actions: tdmAssign,
+                cond: (_ctx, event) => event.data.output,
+              },
+              {
+                target: "fail",
+              },
+            ],
+            onError: { target: "fail" },
+          },
+        },
+        passivity: {
+          invoke: {
+            id: "passivity",
+            src: (context, _evt) =>
+              tdmRequest(
+                context.parameters.endpoint,
+                passivity(context.sessionObject)
+              ),
+            onDone: [
+              {
+                target: "utter",
+                actions: tdmAssign,
+                cond: (_ctx, event) => event.data.output,
+              },
+              {
+                target: "fail",
+              },
+            ],
+            onError: { target: "fail" },
+          },
+        },
+        fail: {},
+      },
     },
-});
+  },
+};

--- a/static/test.html
+++ b/static/test.html
@@ -1,26 +1,26 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8"/>
+  <head>
+    <meta charset="utf-8" />
     <title>SFI Mataffären Test</title>
     <style>
       .App {
-      height: 0 !important;
-      } 
+        height: 0 !important;
+      }
       .control {
-      position: absolute !important;
-      top: 10vh !important;
-      width: 50vw !important;
+        position: absolute !important;
+        top: 10vh !important;
+        width: 50vw !important;
       }
       .select-wrapper {
-      top: 20vh !important;
+        top: 20vh !important;
       }
       .splide__slide img {
-      width: 100%;
-      height: auto;
+        width: 100%;
+        height: auto;
       }
       .splide__pagination__page.is-active {
-      background: #063746 !important;
+        background: #063746 !important;
       }
     </style>
 </head>
@@ -36,44 +36,49 @@
 	 data-i18n-listening="Lyssnar…">
     </div>
 
-<script>
-      const pages = [
-          "sfi_mataffaren"
-      ]
+    <script>
+      const pages = ["cover_web"];
       const turnPage = (segment) => {
-	  event = new CustomEvent('turnpage', { detail: segment });
-	  window.dispatchEvent(event);
-      }
-  const listener = (event) => {
-      window.availableDDDs = event.detail
-      turnPage({"pageNumber": 0, "dddName": pages[0]});
-  }
-  window.addEventListener('setAvailableDDDs', listener);
+        event = new CustomEvent("turnpage", { detail: segment });
+        window.dispatchEvent(event);
+      };
 
-  const listener2 = (event) => {
-      window.talaSpeechState = event.detail
-      console.debug(window.talaSpeechState.value)
-  }
-  window.addEventListener('talaSpeechState', listener2);
+      const listener = (event) => {
+        window.availableDDDs = event.detail;
+        turnPage({ pageNumber: 0, dddName: pages[0] });
+      };
+      window.addEventListener("setAvailableDDDs", listener);
 
-</script>
-<noscript>You need to enable JavaScript to run this app.</noscript>
-<link href="https://cdn.jsdelivr.net/npm/@splidejs/splide@3.6.12/dist/css/splide.min.css" rel="stylesheet"/>
-<link href="http://localhost:1234/index.css" rel="stylesheet"/>
-<script src="https://cdn.jsdelivr.net/npm/@splidejs/splide@3.6.12/dist/js/splide.min.js"
-        integrity="sha256-b/fLMBwSqO9vy/phDPv6OufPpR+VfUL+OsTEkJMPg+Q=" crossorigin="anonymous"></script>
+      const listener2 = (event) => {
+        window.talaSpeechState = event.detail;
+      };
+      window.addEventListener("talaSpeechState", listener2);
 
-<script>
+      const closeTala = () => {
+        window.dispatchEvent(new CustomEvent("talaStop"));
+        document.getElementById("tala-speech").style.visibility = "hidden";
+      };
+    </script>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <link
+      href="https://cdn.jsdelivr.net/npm/@splidejs/splide@3.6.12/dist/css/splide.min.css"
+      rel="stylesheet"
+    />
+    <link href="http://localhost:1234/index.css" rel="stylesheet" />
+    <script
+      src="https://cdn.jsdelivr.net/npm/@splidejs/splide@3.6.12/dist/js/splide.min.js"
+      integrity="sha256-b/fLMBwSqO9vy/phDPv6OufPpR+VfUL+OsTEkJMPg+Q="
+      crossorigin="anonymous"
+    ></script>
+
+    <script>
       // document.addEventListener( 'DOMContentLoaded', function () {
       // 	  new Splide( '#fullscreen-slider', {
       // 		   perPage: 3,
       // 	      rewind : true,).mount();
       // 		    } );
+    </script>
 
-</script>
-
-<script src="http://localhost:1234/index.js"></script>
-
-</body>
-
+    <script src="http://localhost:1234/index.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
This change adds *talaStop* CustomEvent. When received, all state
charts go to 'stopped' state. The intended behaviour is that the
widget should be closed after that. In order to start it again, the
page can either be reloaded or *talaClick* event can be sent. The
widget will go to its initial state after the click.

Additionally, in this change formats the code according to the
https://www.npmjs.com/package/prettier.