### PR TITLE
Make pausing default when clicking during TTS

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -240,10 +240,14 @@ const machine = Machine<SDSContext, any, SDSEvent>({
                       actions: send("ENDSPEECH"),
                     },
                     SELECT: "#asrttsIdle",
-                    CLICK: {
-                      target: "#asrttsIdle",
-                      actions: send("ENDSPEECH"),
-                    },
+                    CLICK: [
+                      {
+                        target: "#asrttsIdle",
+                        actions: send("ENDSPEECH"),
+                        cond: (context) => context.parameters.clickToSkip,
+                      },
+                      { target: "paused" },
+                    ],
                   },
                   exit: "ttsStop",
                 },
@@ -348,6 +352,8 @@ function App({ domElement }: any) {
       azureKey: domElement.getAttribute("data-azure-key"),
       completeTimeout:
         Number(domElement.getAttribute("data-complete-timeout")) || 0,
+      clickToSkip:
+        Boolean(domElement.getAttribute("data-click-to-skip")) || false,
       i18nClickToStart:
         domElement.getAttribute("data-i18n-click-to-start") ||
         "Click to start!",

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -21,6 +21,7 @@ interface Settings {
   asrLanguage: string;
   azureKey?: string;
   completeTimeout: number;
+  clickToSkip: boolean;
   i18nClickToStart: string;
   i18nListening: string;
   i18nSpeaking: string;

--- a/static/test.html
+++ b/static/test.html
@@ -23,18 +23,20 @@
         background: #063746 !important;
       }
     </style>
-</head>
-<body>
-    <div id="tala-speech"
-	 data-azure-authorization-token="<generate token>"
-         data-tdm-endpoint="https://sfi-mataffaren-orchestration-test-pipeline.eu2.ddd.tala.cloud/interact"
-         data-tts-voice="sv-SE, SofieNeural"
-         data-asr-language="sv-SE"
-	 data-i18n-click-to-start="Klicka för att börja!"
-	 data-i18n-click-to-continue="Klicka för att fortsätta"
-	 data-i18n-speaking="Talar…"
-	 data-i18n-listening="Lyssnar…">
-    </div>
+  </head>
+  <body>
+    <div
+      id="tala-speech"
+      data-azure-authorization-token="<generate token>"
+      data-tdm-endpoint="https://sfi-mataffaren-orchestration-test-pipeline.eu2.ddd.tala.cloud/interact"
+      data-tts-voice="sv-SE, SofieNeural"
+      data-asr-language="sv-SE"
+      data-click-to-skip="false"
+      data-i18n-click-to-start="Klicka för att börja!"
+      data-i18n-click-to-continue="Klicka för att fortsätta"
+      data-i18n-speaking="Talar…"
+      data-i18n-listening="Lyssnar…"
+    ></div>
 
     <script>
       const pages = ["cover_web"];


### PR DESCRIPTION
This change enables pausing as a reaction to CLICK during
speaking. Earlier behaviour - skipping the utterance - can be enabled
with a `data-click-to-skip` attribute set to "true".