### PR TITLE
Make TDM device_id a configurable parameter

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -346,6 +346,8 @@ function App({ domElement }: any) {
       "data-azure-authorization-token"
     ),
     parameters: {
+      deviceID:
+        domElement.getAttribute("data-device-id") || "tala-speech-default",
       endpoint: domElement.getAttribute("data-tdm-endpoint"),
       ttsVoice: domElement.getAttribute("data-tts-voice") || "en-US",
       ttsLexicon: domElement.getAttribute("data-tts-lexicon"),

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -15,6 +15,7 @@ interface Segment {
 }
 
 interface Settings {
+  deviceID: string;
   endpoint: string;
   ttsVoice: string;
   ttsLexicon: string;

--- a/src/tdmClient.ts
+++ b/src/tdmClient.ts
@@ -2,13 +2,13 @@ import { MachineConfig, actions, AssignAction } from "xstate";
 
 const { send, assign, choose } = actions;
 
-const startSession = {
+const startSession = (deviceID: string) => ({
   version: "3.3",
-  session: { device_id: "tala-speech" },
+  session: { device_id: deviceID },
   request: {
     start_session: {},
   },
-};
+});
 
 const passivity = (sessionObject: any) => ({
   version: "3.3",
@@ -132,7 +132,10 @@ export const tdmDmMachine: MachineConfig<SDSContext, any, SDSEvent> = {
       invoke: {
         id: "startSession",
         src: (context, _evt) =>
-          tdmRequest(context.parameters.endpoint, startSession),
+          tdmRequest(
+            context.parameters.endpoint,
+            startSession(context.parameters.deviceID)
+          ),
         onDone: [
           {
             target: "idle",
@@ -180,7 +183,10 @@ export const tdmDmMachine: MachineConfig<SDSContext, any, SDSEvent> = {
           invoke: {
             id: "startSession",
             src: (context, _evt) =>
-              tdmRequest(context.parameters.endpoint, startSession),
+              tdmRequest(
+                context.parameters.endpoint,
+                startSession(context.parameters.deviceID)
+              ),
             onDone: [
               {
                 target: "selectSegment",


### PR DESCRIPTION
device_id is configured via "data-device-id" attribute. By default it
is set to be "tala-speech-default".