### PR TITLE
Support speech complete timeout parameter

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -50,7 +50,7 @@ jobs:
         uses: easingthemes/ssh-deploy@main
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-          ARGS: "-avzr --delete"
+          ARGS: "-avzr"
           REMOTE_HOST: ${{ secrets.REMOTE_HOST }}
           REMOTE_USER: ${{ secrets.REMOTE_USER }}
           TARGET: ${{ secrets.REMOTE_TARGET }}

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -54,6 +54,7 @@ interface SDSContext {
   tdmUtterance: string;
   segment: Segment;
   tdmPassivity: number;
+  tdmSpeechCompleteTimeout: number;
   tdmActions: any;
   tdmVisualOutputInfo: any;
   tdmExpectedAlternatives: any;

--- a/src/tdmClient.ts
+++ b/src/tdmClient.ts
@@ -103,7 +103,12 @@ const tdmAssign: AssignAction<SDSContext, any> = assign({
     (event.data.output.visual_output || [{}])[0].visual_information,
   tdmExpectedAlternatives: (_ctx, event) =>
     (event.data.context.expected_input || {}).alternatives,
-  tdmPassivity: (_ctx, event) => event.data.output.expected_passivity,
+  tdmPassivity: (_ctx, event) =>
+    event.data.output.expected_passivity
+      ? event.data.output.expected_passivity * 1000
+      : event.data.output.expected_passivity,
+  tdmSpeechCompleteTimeout: (_ctx, event) =>
+    event.data.output.speech_complete_timeout * 1000,
   tdmActions: (_ctx, event) => event.data.output.actions,
   tdmAsrHints: (_ctx, event) => event.data.context.asr_hints,
 });


### PR DESCRIPTION
Before this change tala-speech applied the same speech complete
timeout for all utterances. Some questions require a longer
speech-complete timeout because they need some reflections from the
user. This change adds support for reading speech-complete timeout
from TDM.

If TDM value for speech-complete timeout is 0, then the default
tala-speech value is used (set by `data-complete-timeout` attribute,
default is 0).
