### PR TITLE
Renew token every 5 minutes; support custom proxy

### DIFF
--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -22,6 +22,7 @@ interface Settings {
   speechRate: string;
   asrLanguage: string;
   azureKey?: string;
+  azureProxyURL?: string;
   completeTimeout: number;
   clickToSkip: boolean;
   i18nClickToStart: string;
@@ -69,6 +70,8 @@ interface SDSContext {
 
 type SDSEvent =
   | { type: "TURNPAGE"; value: Segment }
+  | { type: "GET_TOKEN" }
+  | { type: "NEW_TOKEN" }
   | { type: "TTS_READY" }
   | { type: "TTS_ERROR" }
   | { type: "CLICK" }

--- a/src/tdmClient.ts
+++ b/src/tdmClient.ts
@@ -156,7 +156,7 @@ export const tdmDmMachine: MachineConfig<SDSContext, any, SDSEvent> = {
     },
     idle: {
       on: {
-        CLICK: "init",
+        CLICK: "tdm",
         SELECT: {
           actions: [
             send("CLICK"),
@@ -168,12 +168,6 @@ export const tdmDmMachine: MachineConfig<SDSContext, any, SDSEvent> = {
             }),
           ],
         },
-      },
-    },
-    init: {
-      on: {
-        TTS_READY: "tdm",
-        CLICK: "tdm",
       },
     },
     end: {


### PR DESCRIPTION
This change enables automatic renewals of Azure tokens every 5
minutes. Additionally, it allows specifying a proxy
"data-azure-proxy-url" for fetching Azure tokens without exposing the
key. The precedence is the following: explicit token (left for
backward capability) > proxy url > azure key. Tokens which are set
explicitly are not renewed.