### PR TITLE
Wait infinitely if passivity is null

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: dist
-          path: ${{ github.event.number }}
+          path: ${{ github.event.number == 0 && 'master' ||  format('{0}', github.event.number) }}
       - name: Display structure of downloaded files
         run: ls -R
       - name: Deploy to Staging server

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -194,7 +194,7 @@ const machine = Machine<SDSContext, any, SDSEvent>({
                       { type: "TIMEOUT" },
                       {
                         delay: (context) =>
-                          context.tdmPassivity ?? defaultPassivity,
+                          context.tdmPassivity ?? 1000 * 3600 * 24,
                         id: "timeout",
                       }
                     ),
@@ -454,7 +454,7 @@ function App({ domElement }: any) {
           }
           const utterance = new context.ttsUtterance(content);
           console.log("S>", context.ttsAgenda, {
-            passivity: `${context.tdmPassivity ?? defaultPassivity} ms`,
+            passivity: `${context.tdmPassivity ?? "∞"} ms`,
             speechCompleteTimeout: `${
               context.tdmSpeechCompleteTimeout ||
               context.parameters.completeTimeout


### PR DESCRIPTION
Before this change, tala-speech was resetting TDM passivity value
equal to null to default hard-coded value. Now it will wait
infinitely (technically for 24 hours).

The default value is now used in only one case -- when user pauses the
recognition and then starts it again. In this case we assume that the
user is about to say something, and we don't need to wait for too
long.