### PR TITLE
Improve latency by avoiding OPTIONS request

### DIFF
--- a/src/tdmClient.ts
+++ b/src/tdmClient.ts
@@ -85,6 +85,7 @@ const tdmRequest = (endpoint: string, requestBody: any) =>
   fetch(
     new Request(endpoint, {
       method: "POST",
+      mode: "no-cors",
       headers: {
         "Content-type": "application/json",
       },


### PR DESCRIPTION
This change sets fetch option mode: "cors" which skips the OPTIONS turn before POST is sent. This changes verifies if this is an option here (Ha!)