### PR TITLE
Dispatch a custom event with dialogue ends

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -410,6 +410,24 @@ function App({ domElement }: any) {
           });
           window.dispatchEvent(event);
         }),
+        dispatchEndOfDialogueEvent: asEffect(() => {
+          const event = new CustomEvent<any>("endOfDialogue", {
+            detail: {
+              questions: 2,
+              correctAnswers: 2,
+              correctAnswersDetailed: {
+                firstAttempt: 1,
+                afterHint: 0,
+                afterAlternatives: 1,
+              },
+              neutralAnswers: 0,
+              incorrectAnswers: 0,
+              hintsReceived: 1,
+            },
+          });
+          window.dispatchEvent(event);
+        }),
+
         recLogResult: (context: SDSContext) => {
           console.log("U>", context.recResult[0]["utterance"], {
             confidence: context.recResult[0]["confidence"],

--- a/src/tdmClient.ts
+++ b/src/tdmClient.ts
@@ -251,6 +251,7 @@ export const tdmDmMachine: MachineConfig<SDSContext, any, SDSEvent> = {
                           "EndConversation",
                         ].includes(item.name)
                       ),
+                    actions: "dispatchEndOfDialogueEvent",
                   },
                   {
                     target: "#root.dm.tdm.passivity",


### PR DESCRIPTION
This change makes the widget emit an event when the user is done with
a dialogue.

WIP performace metrics