### PR TITLE
Support incremental TTS source

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -206,6 +206,7 @@ const machine = Machine<SDSContext, any, SDSEvent>({
                         FILLER_DELAY: {
                           target: "speakingIdle",
                           actions: "addFiller",
+                          cond: (context) => context.buffer.includes(" "),
                         },
                       },
                     },
@@ -614,11 +615,15 @@ function App({ domElement }: any) {
             confidence: context.recResult[0]["confidence"],
           });
         },
-        addFiller: (context: SDSContext) => {
-          if (context.buffer.charAt(context.buffer.length - 1) !== ".") {
-            context.buffer = context.buffer + " um, ";
-          }
-        },
+        addFiller: assign((context) => {
+          const spaceIndex = context.buffer.lastIndexOf(" ");
+          return {
+            buffer:
+              context.buffer.substring(0, spaceIndex) +
+              " um," +
+              context.buffer.substring(spaceIndex),
+          };
+        }),
         recStart: asEffect((context) => {
           (context.asr.grammars as any).phrases = context.tdmAsrHints;
           context.asr.start();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -491,6 +491,9 @@ function App({ domElement }: any) {
     parameters: {
       deviceID:
         domElement.getAttribute("data-device-id") || "tala-speech-default",
+      sessionObjectAdditions:
+        JSON.parse(domElement.getAttribute("data-session-object-additions")) ||
+        {},
       endpoint: domElement.getAttribute("data-tdm-endpoint"),
       ttsVoice:
         domElement.getAttribute("data-tts-voice") || "en-US-DavisNeural",

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -39,7 +39,6 @@ interface SDSContext {
   parameters: Settings;
   asr: SpeechRecognition;
   tts: SpeechSynthesis;
-  voice: SpeechSynthesisVoice;
   ttsUtterance: MySpeechSynthesisUtterance;
   recResult: Hypothesis[];
   hapticInput: string;

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -25,6 +25,7 @@ interface Settings {
   azureKey?: string;
   azureProxyURL?: string;
   completeTimeout: number;
+  fillerDelay: number;
   clickToSkip: boolean;
   i18nClickToStart: string;
   i18nListening: string;

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -62,6 +62,8 @@ interface SDSContext {
   azureAuthorizationToken: string;
   audioCtx: any;
   stream: any;
+  buffer: string;
+  streamingDone: boolean;
 }
 
 type SDSEvent =
@@ -84,4 +86,7 @@ type SDSEvent =
   | { type: "LISTEN" }
   | { type: "TIMEOUT" }
   | { type: "SPEAK"; value: string }
+  | { type: "STREAMING_CHUNK"; value: string }
+  | { type: "STREAMING_DONE" }
+  | { type: "STREAMING_RESET" }
   | { type: "SPEAKING_STREAM" };

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -16,6 +16,7 @@ interface Segment {
 
 interface Settings {
   deviceID: string;
+  sessionObjectAdditions: any;
   endpoint: string;
   ttsVoice: string;
   ttsLexicon: string;

--- a/src/tdmClient.ts
+++ b/src/tdmClient.ts
@@ -3,9 +3,9 @@ import { MachineConfig, actions, AssignAction } from "xstate";
 const { send, assign, choose } = actions;
 
 const VERSION = "3.4";
-const startSession = (deviceID: string) => ({
+const startSession = (deviceID: string, sessionObjectAdditions: any) => ({
   version: VERSION,
-  session: { device_id: deviceID },
+  session: { device_id: deviceID, ...sessionObjectAdditions },
   request: {
     start_session: {},
   },
@@ -140,7 +140,10 @@ export const tdmDmMachine: MachineConfig<SDSContext, any, SDSEvent> = {
         src: (context, _evt) =>
           tdmRequest(
             context.parameters.endpoint,
-            startSession(context.parameters.deviceID)
+            startSession(
+              context.parameters.deviceID,
+              context.parameters.sessionObjectAdditions
+            )
           ),
         onDone: [
           {

--- a/src/tdmClient.ts
+++ b/src/tdmClient.ts
@@ -145,7 +145,7 @@ export const tdmDmMachine: MachineConfig<SDSContext, any, SDSEvent> = {
         onDone: [
           {
             target: "idle",
-            actions: [tdmAssign, "setAvailableDDDs", "readServerEvents"],
+            actions: [tdmAssign, "setAvailableDDDs", "createEventsFromChunks"],
             cond: (_ctx, event) => event.data.output,
           },
           {


### PR DESCRIPTION
This changeset contains:
1. Support for incremental TTS streaming from given EventSource (the source is now hard-coded)
    - "um" is uttered if there is a 500ms delay in getting the chunks from EventSource
    - the delay is configurable via `"data-filler-delay"` attribute (in ms)
3. BREAKING: voice selection not based on search anymore but via explicit shorthand (see Azure docs)
4. (bugfix) Skip/pause functionality selection
5. Support for extra parameters in sessionObject (passed via `"data-session-object-additions"` <div> attribute)