### PR TITLE
Adapt to new events format for streamed data

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -574,8 +574,7 @@ function App({ domElement }: any) {
         createEventsFromChunks: (context: SDSContext) => {
           if (!context.stream) {
             context.stream = new EventSource(
-              "https://tar.dc1.pratb.art:1880/sse/" +
-                context.sessionObject.session_id,
+              "https://tala-sse.azurewebsites.net/sse/${context.sessionObject.session_id}"
             );
             context.stream.onmessage = function (event: any) {
               if (event.data !== "[CLEAR]") {


### PR DESCRIPTION
The format of streamed data will change from events like the following

 - [CLEAR]
 - some utterance
 - [DONE]

into JSON events like

 - {"event": "STREAMING_CLEAR"}
 - {"event": "STREAMING_CHUNK", "data": "some utterance"}
 - {"event": "STREAMING_DONE"}

This change updates Tala Speech 1 so that it can handle the new event format.