### PR TITLE
Expose state "meta" to window.TalaSpeechUIState

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,6 +20,8 @@ jobs:
       - run: yarn
       - run: yarn exec tsc --outDir dist/lib
       - run: yarn exec vite build --outDir dist/browser
+      - name: Bump version to the tag
+        run: npm version from-git
       - name: Publish to NPM registry
         run: npm publish
         env:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tala-speech",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "license": "GPL-3.0",
   "scripts": {
     "build": "vite build --outDir dist/browser",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "version": "2.1.3",
   "license": "GPL-3.0",
   "scripts": {
-    "build": "vite build",
+    "build": "vite build --outDir dist/browser",
+    "compile": "tsc --outDir dist/lib",
     "dev": "vite"
   },
   "author": "Talkamatic AB",
   "packageManager": "yarn@4.0.2",
   "dependencies": {
-    "speechstate": "^2.0.3"
+    "speechstate": "^2.0.4"
   },
   "devDependencies": {
     "@statelyai/inspect": "^0.2.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,14 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es2016",
+    "target": "es2017",
     // "strict": true,
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
     "forceConsistentCasingInFileNames": true,
     "outDir": "./dist",
-    "lib": ["dom", "es2016"],
+    "lib": ["dom", "es2017"],
     "moduleResolution": "node"
   },
   "include": ["src/index.ts"]


### PR DESCRIPTION
This change exposes meta values for states available in SpeechState to
`window.TalaSpeechUIState`. If speech resources are not yet prepared,
usual state names from tala-speech are used. This behaviour might
change after checking resulting state names against the states of the
consumer app. In future we should also add meta values to tala-speech.